### PR TITLE
Update some rules.

### DIFF
--- a/native-libs/libfire.so.json
+++ b/native-libs/libfire.so.json
@@ -2,7 +2,7 @@
     "label": "Sofire",
     "team": "Baidu",
     "iconUrl": "",
-    "contributors": ["Janet-Baker"],
+    "contributors": ["Janet-Baker", "ArthurCyy"],
     "description": "业务安全风控 AFD，是基于业务场景，结合 IP 画像、设备指纹、黑卡检测、威胁情报等多维度信息实时识别风险的专业防护产品。AFD 能够有效识别和解决渠道推广、账号安全、支付安全、营销活动等作弊问题，避免企业出现巨大的经济损失。Android 安全 SDK 又名——昊天 SDK，是一个基于海量威胁情报数据的智能分析平台， 打通了移动、云、PC 的全链条安全数据，利用深度学习人工智能平台从海量的安全事件中进行关联分析，能感知出潜在的互联网威胁以及 APT 事件，并能对攻击阵营的基础设施和技术手段进行分析识别，告别被动防御局面， 为用户提供更加安全的互联网体验。",
     "relativeUrl": "https://cloud.baidu.com/doc/AFD/s/Ijwvy4s7b"
 }

--- a/native-libs/libhs.so.json
+++ b/native-libs/libhs.so.json
@@ -1,8 +1,8 @@
 {
-    "label": "Hyperscan",
-    "team": "Intel",
+    "label": "Sofire",
+    "team": "Baidu",
     "iconUrl": "",
-    "contributors": ["ArthurCyy"],
-    "description": "Hyperscan is a high-performance multiple regex matching library. It follows the regular expression syntax of the commonly-used libpcre library, but is a standalone library with its own C API.接入后，能让您的 App 轻松拥有投屏与镜像能力，从而在满足用户需求的同时，也将您的内容分发上大屏。可广泛应用于通话，视频，音乐，直播，游戏，教育，办公等场景。",
-    "relativeUrl": "https://github.com/intel/hyperscan"
+    "contributors": ["Janet-Baker", "ArthurCyy"],
+    "description": "业务安全风控 AFD，是基于业务场景，结合 IP 画像、设备指纹、黑卡检测、威胁情报等多维度信息实时识别风险的专业防护产品。AFD 能够有效识别和解决渠道推广、账号安全、支付安全、营销活动等作弊问题，避免企业出现巨大的经济损失。Android 安全 SDK 又名——昊天 SDK，是一个基于海量威胁情报数据的智能分析平台， 打通了移动、云、PC 的全链条安全数据，利用深度学习人工智能平台从海量的安全事件中进行关联分析，能感知出潜在的互联网威胁以及 APT 事件，并能对攻击阵营的基础设施和技术手段进行分析识别，告别被动防御局面， 为用户提供更加安全的互联网体验。",
+    "relativeUrl": "https://cloud.baidu.com/doc/AFD/s/Ijwvy4s7b"
 }

--- a/native-libs/libmotion_photo_mace.so.json
+++ b/native-libs/libmotion_photo_mace.so.json
@@ -1,8 +1,0 @@
-{
-    "label": "MACE",
-    "team": "Xiaomi",
-    "iconUrl": "",
-    "contributors": ["ArthurCyy"],
-    "description": "Mobile AI Compute Engine (MACE) 是一个专为移动端异构计算平台(支持 Android, iOS, Linux, Windows)优化的神经网络计算框架。",
-    "relativeUrl": "https://github.com/XiaoMi/mace"
-}

--- a/providers-libs/com.baidu.sofire.MyProvider.json
+++ b/providers-libs/com.baidu.sofire.MyProvider.json
@@ -2,7 +2,7 @@
     "label": "Sofire",
     "team": "Baidu",
     "iconUrl": "",
-    "contributors": ["Janet-Baker"],
+    "contributors": ["Janet-Baker", "ArthurCyy"],
     "description": "业务安全风控 AFD，是基于业务场景，结合 IP 画像、设备指纹、黑卡检测、威胁情报等多维度信息实时识别风险的专业防护产品。AFD 能够有效识别和解决渠道推广、账号安全、支付安全、营销活动等作弊问题，避免企业出现巨大的经济损失。Android 安全 SDK 又名——昊天 SDK，是一个基于海量威胁情报数据的智能分析平台， 打通了移动、云、PC 的全链条安全数据，利用深度学习人工智能平台从海量的安全事件中进行关联分析，能感知出潜在的互联网威胁以及 APT 事件，并能对攻击阵营的基础设施和技术手段进行分析识别，告别被动防御局面， 为用户提供更加安全的互联网体验。",
     "relativeUrl": "https://cloud.baidu.com/doc/AFD/s/Ijwvy4s7b"
 }

--- a/services-libs/com.baidu.sofire.MyService.json
+++ b/services-libs/com.baidu.sofire.MyService.json
@@ -1,0 +1,8 @@
+{
+    "label": "Sofire",
+    "team": "Baidu",
+    "iconUrl": "",
+    "contributors": ["Janet-Baker", "ArthurCyy"],
+    "description": "业务安全风控 AFD，是基于业务场景，结合 IP 画像、设备指纹、黑卡检测、威胁情报等多维度信息实时识别风险的专业防护产品。AFD 能够有效识别和解决渠道推广、账号安全、支付安全、营销活动等作弊问题，避免企业出现巨大的经济损失。Android 安全 SDK 又名——昊天 SDK，是一个基于海量威胁情报数据的智能分析平台， 打通了移动、云、PC 的全链条安全数据，利用深度学习人工智能平台从海量的安全事件中进行关联分析，能感知出潜在的互联网威胁以及 APT 事件，并能对攻击阵营的基础设施和技术手段进行分析识别，告别被动防御局面， 为用户提供更加安全的互联网体验。",
+    "relativeUrl": "https://cloud.baidu.com/doc/AFD/s/Ijwvy4s7b"
+}


### PR DESCRIPTION
There are multiple applications that have `libhs.so`, which is not Hyperscan, but Sofire, which can be misleading. The existing Hyperscan rule description has some errors and there are more applications using Sofire, so it is more appropriate to change it to Sofire.

Add a rule for Sofire.

`libmotion_photo_mace.so` is Xiaomi's private library, which exists only in Bokeh. Only `libmace.so` should be kept.