### PR TITLE
fix: Wrong library link

### DIFF
--- a/native-libs/libarcore_sdk_c.so.json
+++ b/native-libs/libarcore_sdk_c.so.json
@@ -4,5 +4,5 @@
     "iconUrl": "",
     "contributors": ["Absinthe"],
     "description": "借助 ViroCore，Android 开发者现在可以使用熟悉的语言和工具来构建沉浸式 AR/VR 应用。",
-    "relativeUrl": "https://developer.android.com/ndk/guides/cpp-support/"
+    "relativeUrl": "https://github.com/ViroCommunity/virocore"
 }


### PR DESCRIPTION
Seems to have been accidentally copied from another library in https://github.com/LibChecker/LibChecker-Rules/commit/3573032c6edbefe45ec6cf9174ea4f40d20219b1