### PR TITLE
修正多文件中的中文描述错别字，更新华为账号服务的简介

### DIFF
--- a/activities-libs/com/huawei/hms/account/internal/ui/activity/AccountSignInHubActivity.json
+++ b/activities-libs/com/huawei/hms/account/internal/ui/activity/AccountSignInHubActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "通过华为账号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
+                "description": "华为账号服务（HUAWEI Account Kit）为您提供了简单、安全的登录授权功能，方便用户快捷登录。用户不必输入账号、密码和繁琐验证，就可以通过“华为账号登录”快速登录，即刻使用您的App。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         },
@@ -20,7 +20,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "Through Huawei Account Open Services, Android applications can easily and securely implement quick login authorization, read SMS verification codes, and other functions. With user authorization credentials, applications can quickly access and call the public APIs provided by Huawei.",
+                "description": "HUAWEI Account Kit provides you with simple, secure, and quick sign-in and authorization functions. Instead of entering accounts and passwords and waiting for authentication, users can just tap the Sign in with HUAWEI ID button to quickly and securely sign in to your app with their HUAWEI IDs.",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         }

--- a/activities-libs/com/huawei/hms/account/internal/ui/activity/AccountSignInHubActivity.json
+++ b/activities-libs/com/huawei/hms/account/internal/ui/activity/AccountSignInHubActivity.json
@@ -3,12 +3,12 @@
         {
             "locale": "zh-Hans",
             "data": {
-                "label": "华为帐号服务",
+                "label": "华为账号服务",
                 "dev_team": "Huawei",
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "通过华为帐号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
+                "description": "通过华为账号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         },

--- a/activities-libs/com/huawei/hms/hihealth/BridgeClientActivity.json
+++ b/activities-libs/com/huawei/hms/hihealth/BridgeClientActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为帐号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
+                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为账号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/health-introduce-0000001053684429"
             }
         },

--- a/activities-libs/com/huawei/hms/hihealth/activity/HealthKitAuthHubActivity.json
+++ b/activities-libs/com/huawei/hms/hihealth/activity/HealthKitAuthHubActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为帐号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
+                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为账号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/health-introduce-0000001053684429"
             }
         },

--- a/activities-libs/com/huawei/hms/hihealth/activity/HealthKitTransparentActivity.json
+++ b/activities-libs/com/huawei/hms/hihealth/activity/HealthKitTransparentActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为帐号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
+                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为账号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/health-introduce-0000001053684429"
             }
         },

--- a/activities-libs/com/huawei/hms/hihealth/activity/HealthKitWebViewActivity.json
+++ b/activities-libs/com/huawei/hms/hihealth/activity/HealthKitWebViewActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为帐号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
+                "description": "华为运动健康服务（HUAWEI Health Kit，简称 Health Kit）是为华为生态应用打造的基于华为账号和用户授权的运动健康数据开放平台。面向消费者，支持运动健康数据存储、灵活授权分享机制；面向开发者和合作伙伴提供数据平台和运动健康开放能力，开发者和合作伙伴可以基于多种类型数据，构建运动健康领域应用与服务。Health Kit 连接硬件设备与生态应用，为消费者提供健康关怀和运动指导，打造优质服务体验。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/health-introduce-0000001053684429"
             }
         },

--- a/activities-libs/com/huawei/hms/hwid/activity/BridgeActivity.json
+++ b/activities-libs/com/huawei/hms/hwid/activity/BridgeActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "通过华为账号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
+                "description": "华为账号服务（HUAWEI Account Kit）为您提供了简单、安全的登录授权功能，方便用户快捷登录。用户不必输入账号、密码和繁琐验证，就可以通过“华为账号登录”快速登录，即刻使用您的App。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         },
@@ -20,7 +20,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "Through Huawei Account Open Services, Android applications can easily and securely implement quick login authorization, read SMS verification codes, and other functions. With user authorization credentials, applications can quickly access and call the public APIs provided by Huawei.",
+                "description": "HUAWEI Account Kit provides you with simple, secure, and quick sign-in and authorization functions. Instead of entering accounts and passwords and waiting for authentication, users can just tap the Sign in with HUAWEI ID button to quickly and securely sign in to your app with their HUAWEI IDs.",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         }

--- a/activities-libs/com/huawei/hms/hwid/activity/BridgeActivity.json
+++ b/activities-libs/com/huawei/hms/hwid/activity/BridgeActivity.json
@@ -3,12 +3,12 @@
         {
             "locale": "zh-Hans",
             "data": {
-                "label": "华为帐号服务",
+                "label": "华为账号服务",
                 "dev_team": "Huawei",
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "通过华为帐号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
+                "description": "通过华为账号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         },

--- a/activities-libs/com/huawei/hms/hwid/internal/ui/activity/HwIdSignInHubActivity.json
+++ b/activities-libs/com/huawei/hms/hwid/internal/ui/activity/HwIdSignInHubActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "通过华为账号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
+                "description": "华为账号服务（HUAWEI Account Kit）为您提供了简单、安全的登录授权功能，方便用户快捷登录。用户不必输入账号、密码和繁琐验证，就可以通过“华为账号登录”快速登录，即刻使用您的App。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         },
@@ -20,7 +20,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "Through Huawei Account Open Services, Android applications can easily and securely implement quick login authorization, read SMS verification codes, and other functions. With user authorization credentials, applications can quickly access and call the public APIs provided by Huawei.",
+                "description": "HUAWEI Account Kit provides you with simple, secure, and quick sign-in and authorization functions. Instead of entering accounts and passwords and waiting for authentication, users can just tap the Sign in with HUAWEI ID button to quickly and securely sign in to your app with their HUAWEI IDs.",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         }

--- a/activities-libs/com/huawei/hms/hwid/internal/ui/activity/HwIdSignInHubActivity.json
+++ b/activities-libs/com/huawei/hms/hwid/internal/ui/activity/HwIdSignInHubActivity.json
@@ -3,12 +3,12 @@
         {
             "locale": "zh-Hans",
             "data": {
-                "label": "华为帐号服务",
+                "label": "华为账号服务",
                 "dev_team": "Huawei",
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "通过华为帐号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
+                "description": "通过华为账号开放服务，Android 应用可以方便、安全地实现快速登录授权、读取短信验证码等功能，凭借用户授权凭证，应用可快速访问调用华为提供的公开 API。",
                 "source_link": "https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/introduction-0000001050048870"
             }
         },

--- a/activities-libs/com/xiaomi/account/openauth/AuthorizeActivity.json
+++ b/activities-libs/com/xiaomi/account/openauth/AuthorizeActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "小米帐号授权登录服务是小米公司向开发者提供的，基于 OAuth 2.0 标准协议的小米帐号快捷登录服务，用户可以方便快捷的使用小米帐号登录您的网站或者移动应用。",
+                "description": "小米账号授权登录服务是小米公司向开发者提供的，基于 OAuth 2.0 标准协议的小米账号快捷登录服务，用户可以方便快捷的使用小米账号登录您的网站或者移动应用。",
                 "source_link": "https://dev.mi.com/console/appservice/account.html"
             }
         },

--- a/activities-libs/com/xiaomi/accountsdk/diagnosis/ui/PassportDiagnosisActivity.json
+++ b/activities-libs/com/xiaomi/accountsdk/diagnosis/ui/PassportDiagnosisActivity.json
@@ -8,7 +8,7 @@
                 "rule_contributors": [
                     "Absinthe"
                 ],
-                "description": "小米帐号授权登录服务是小米公司向开发者提供的，基于 OAuth 2.0 标准协议的小米帐号快捷登录服务，用户可以方便快捷的使用小米帐号登录您的网站或者移动应用。",
+                "description": "小米账号授权登录服务是小米公司向开发者提供的，基于 OAuth 2.0 标准协议的小米账号快捷登录服务，用户可以方便快捷的使用小米账号登录您的网站或者移动应用。",
                 "source_link": "https://dev.mi.com/console/appservice/account.html"
             }
         },


### PR DESCRIPTION
华为和小米已将“帐号”更改为“账号”。此 PR 同步了上述用语更改。

此外，根据华为文档更新了华为账号服务的简介。

![图片](https://github.com/user-attachments/assets/a67cbc1f-cca5-4a5e-9ec1-01b6fe34fd1d)

![图片](https://github.com/user-attachments/assets/1d57725b-0db4-42d5-a760-3b8d4b0031f4)
