### PR TITLE
Document chart rule contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@
 
 LibChecker 规则仓库，请按照模板规范提交 issue。
 
-图表统计规则的目录结构、规则格式与贡献流程请参阅
+图表统计规则的目录结构、完整参数说明与贡献流程请参阅
+[`chart/README.zh-Hans.md`](chart/README.zh-Hans.md)，英文版见
 [`chart/README.md`](chart/README.md)。

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,161 +1,933 @@
-# Chart rules
+# Chart rule contribution guide
+
+English | [简体中文](README.zh-Hans.md)
 
 This directory contains the declarative statistics shown on LibChecker's chart
-page. Contributors provide data and conditions; the APK owns all APK, DEX,
-manifest, and native-file traversal. Rules cannot execute scripts or arbitrary
-code.
+page. A rule describes the data that LibChecker should inspect, the condition
+that produces a match, and the labels and icon shown to the user.
 
-## Repository layout
+Rules cannot execute scripts or arbitrary code. LibChecker owns all APK, DEX,
+manifest, and native-file traversal. A rule can only use evidence and operators
+that the installed app already implements.
 
-- `schema/v1/`: JSON schemas for source rules and generated manifests.
-- `rules/`: one reviewed statistic definition per JSON file.
-- `icons/`: SVG assets referenced by online rules.
-- `tools/build_bundle.py`: validator and deterministic bundle generator.
-- `cloud/v1/`: generated files consumed by LibChecker.
+## Before you start
 
-The rule filename should match the final segment of its stable ID. IDs use the
-`official.` prefix and must never be reused for a different statistic. Increase
-`revision` whenever a published rule's detection or presentation changes.
+Answer these questions before writing JSON:
 
-## Rule envelope
+1. What does the chart measure, and why is it useful to LibChecker users?
+2. Which installed-app evidence proves a match?
+3. Can an app produce one yes/no result, or can it match several capabilities?
+4. Is there a primary HTTPS source that explains the technology or capability?
+5. Can you test the rule against both matching and non-matching APKs?
 
-Every source rule contains:
+Schema v1 supports only the evidence listed in [Evidence reference](#evidence-reference).
+If your rule needs another source, such as a DEX field, resource-table entry,
+native symbol, certificate property, or arbitrary file content, propose a
+generic evidence provider in the LibChecker app first. Do not encode a
+workaround in the rule.
 
-- `id`, `revision`, and `source: official`.
-- `title.translations` with at least `en` and `zh-Hans`.
-- `details.description.translations` with at least `en` and `zh-Hans`, plus
-  one HTTPS `details.referenceUrl` for the in-app introduction dialog.
-- `icon.asset`, plus an optional render mode and tint role.
-- `calculation`, using one of the calculation types below.
-- optional chart metadata such as `fingerprint`.
-- optional `releaseChannel`, which defaults to `stable`.
+New rules should normally start with `"releaseChannel": "preview-only"`. Move
+them to `stable` only after the preview bundle has been tested with a compatible
+LibChecker build.
 
-Do not use `zh` or `zh-CN`. Simplified Chinese translations must use
-`zh-Hans`. English is the runtime fallback locale.
+## Contribution workflow
 
-`releaseChannel` controls publication without changing APK behavior:
+1. Fork the repository and create a topic branch.
+2. Choose the closest example in `rules/`:
+   - [`flutter.json`](rules/flutter.json) for exact native-library detection.
+   - [`itgsa.json`](rules/itgsa.json) for facets, recursive conditions, DEX
+     queries, and manifest receiver actions.
+   - The [predicate example](#predicate-calculations) below for a numeric
+     comparison.
+3. Add one UTF-8 JSON file under `rules/`. Use four-space indentation and name
+   the file after the final segment of the rule ID.
+4. Add the referenced SVG under `icons/`.
+5. Update the tests that enumerate rule IDs, icons, catalog size, and stable
+   channel contents. Add focused assertions for the new detection data.
+6. Run the unit tests and build a preview bundle in a temporary directory.
+7. Test the preview rule with known matching and non-matching apps.
+8. Regenerate `cloud/v1/chart.bundle` and `cloud/v1/manifest.json` with the
+   bundle version and minimum app version agreed for the target branch.
+9. Submit the source rule, icon, tests, generated bundle, and manifest in one
+   pull request. Include your evidence source and manual test results in the PR
+   description.
 
-- `stable` rules are included in preview and stable bundles.
-- `preview-only` rules are included only in preview bundles.
-
-The builder removes this source-only field from the generated catalog. Mark
-experimental rules `preview-only`; never rely on manually deleting them before
-a stable release.
-
-## Calculation types
-
-### Predicate
-
-Use `kind: predicate` for one binary question. A predicate supplies localized
-`matchedTitle` and `unmatchedTitle`, then either one complete evidence/operator/
-value tuple or one recursive `condition`.
-
-### Facets
-
-Use `kind: facets` when an app may match several named capabilities at once.
-The facets object supplies localized matched/unmatched titles and an ordered
-`items` array. Each item contains:
-
-- a rule-local, stable, unique `id`;
-- a localized `title` used as the app-row chip;
-- exactly one `condition`.
-
-An app enters the matched group when at least one facet matches. Every matching
-facet is displayed in rule order. Do not duplicate the facet conditions in a
-separate root `any`: that creates two sources of truth. A rule may define at
-most eight facets, and facet titles may contain at most 40 characters.
-
-Facets describe overlapping capabilities. Do not use them for mutually
-exclusive buckets or numeric distributions; those require dedicated
-calculation types.
-
-## Conditions and evidence
-
-Conditions are restricted to `all`, `any`, `not`, or one typed evidence leaf.
-The validator limits condition depth, node count, child count, query count, and
-string length.
-
-Schema v1 currently supports:
-
-- numeric comparison of `target_sdk`;
-- exact library-name membership through `native_library`;
-- `dex_class` queries using an exact or prefix class name, string constants,
-  and method references;
-- `manifest_receiver_action` membership.
-
-Name, string, and method constraints inside one DEX class query must be
-satisfied by the same class. Use separate queries when constraints may be found
-in different classes. Use `any` when either DEX or manifest evidence is an
-accepted detection path.
-
-Rules can compose only evidence implemented by the current APK. A genuinely
-new source such as a DEX field definition, DEX field reference, resource-table
-entry, or native symbol requires one generic APK evidence provider first. Do
-not work around this boundary with executable code, reflection, file paths, or
-network URLs.
-
-## Icons
-
-Online icons live under `icons/` and are referenced by a repository-relative
-asset path; rules must not contain an external icon URL. Built-in statistics
-continue to use APK drawable resources.
-
-SVG files must:
-
-- use a `0 0 1024 1024` viewBox;
-- place the intended artwork in an approximately `800 x 800` center boundary;
-- remain below 64 KiB;
-- avoid scripts, styles, text, linked images, entities, external references,
-  and `url(...)` content.
-
-Use `renderMode: original` only when brand colors are meaningful. Otherwise use
-`monochrome` and let LibChecker apply its theme tint.
-
-## Details and references
-
-Every online rule provides a short, neutral introduction in
-`details.description`. Describe the technology or capability itself; do not
-claim that the current app matches because LibChecker appends the actual
-analysis result at runtime. Faceted rules automatically list the matched facet
-titles below the introduction.
-
-`details.referenceUrl` must use HTTPS and should point to the primary project,
-standards body, or platform documentation. Do not use tracking links, URL
-shorteners, affiliate links, or unreviewed third-party summaries.
-
-## Validation and bundle generation
-
-Run from the repository root:
+Run commands from the repository root:
 
 ```shell
 python3 -m unittest chart.tools.test_build_bundle
-python3 chart/tools/build_bundle.py --bundle-version 10 --channel stable --minimum-app-version-code 2731
+python3 chart/tools/build_bundle.py \
+  --bundle-version 12 \
+  --channel preview \
+  --minimum-app-version-code 2731 \
+  --output-dir /tmp/libchecker-chart-preview
 ```
 
-Set `minimum-app-version-code` to the exact first compatible APK version before
-publishing. Use `0` only when every supported published APK already implements
-the rule's calculation and evidence types. Bundle versions must increase
-independently on each published branch.
+The numbers above are examples. Read `chart/cloud/v1/manifest.json` and the
+target branch before choosing a bundle version or minimum app version.
 
-The preview build includes stable and preview-only rules. A stable build uses
-`--channel stable`; its tests must prove that preview-only rules are absent.
-Generated `chart.bundle` output is deterministic, checksummed, size-limited,
-and committed together with `manifest.json`.
+## Repository layout
 
-## Contribution checklist
+| Path | Purpose |
+| --- | --- |
+| `rules/` | Reviewed source definitions, one JSON file per statistic. |
+| `icons/` | SVG assets referenced by source rules. |
+| `schema/v1/chart-rule.schema.json` | Machine-readable schema for source rules. |
+| `schema/v1/manifest.schema.json` | Machine-readable schema for the generated manifest. |
+| `tools/build_bundle.py` | Validator and deterministic bundle generator. |
+| `tools/test_build_bundle.py` | Source validation and bundle regression tests. |
+| `cloud/v1/chart.bundle` | Generated catalog and icons consumed by LibChecker. |
+| `cloud/v1/manifest.json` | Generated version, compatibility, size, and checksum metadata. |
 
-1. Add or update one source JSON, its localized details and primary reference,
-   and its SVG asset.
-2. Use only supported evidence and the narrowest condition that avoids false
-   positives.
-3. Add `en` and `zh-Hans` for every title and facet.
-4. Add focused builder tests for detection data, ordering, channels, and icon
-   rendering mode.
-5. Run the unit tests and generate the preview bundle with a higher version.
-6. Test the rule from the preview branch in a compatible LibChecker APK.
-7. Only after the preview result is verified, generate the stable bundle and
-   confirm that every `preview-only` rule is excluded.
+## Minimal rule
 
-If a bad bundle is published, restore the last known-good generated bundle and
-manifest with a higher bundle version. Compatible APKs retain their cached
-bundle when a download, checksum, schema, or minimum-version check fails.
+This is a complete single-predicate rule:
+
+```json
+{
+    "id": "official.example-sdk",
+    "revision": 1,
+    "source": "official",
+    "releaseChannel": "preview-only",
+    "title": {
+        "translations": {
+            "en": "Example SDK",
+            "zh-Hans": "示例 SDK"
+        }
+    },
+    "details": {
+        "description": {
+            "translations": {
+                "en": "Example SDK provides a documented capability for Android apps.",
+                "zh-Hans": "示例 SDK 为 Android 应用提供一项有公开文档的能力。"
+            }
+        },
+        "referenceUrl": "https://example.com/android-sdk"
+    },
+    "icon": {
+        "asset": "icons/example-sdk.svg",
+        "renderMode": "monochrome",
+        "tintRole": "on_surface"
+    },
+    "calculation": {
+        "kind": "predicate",
+        "predicate": {
+            "evidence": "native_library",
+            "operator": "contains",
+            "value": {
+                "string": "libexample.so"
+            },
+            "matchedTitle": {
+                "translations": {
+                    "en": "Example SDK apps",
+                    "zh-Hans": "示例 SDK 应用"
+                }
+            },
+            "unmatchedTitle": {
+                "translations": {
+                    "en": "Other apps",
+                    "zh-Hans": "其他应用"
+                }
+            }
+        }
+    },
+    "fingerprint": "artifact"
+}
+```
+
+## Top-level fields
+
+The source schema does not allow unknown fields. The following fields are
+available to official online rules.
+
+| Field | Required | Type or allowed values | Meaning |
+| --- | --- | --- | --- |
+| `id` | Yes | String matching `official.<name>` | Permanent identity of the statistic. |
+| `revision` | Yes | Integer, minimum `1` | Version of this rule definition. |
+| `source` | Yes | `official` | Online rules in this repository are official rules. |
+| `title` | Yes | Translated text | Chart title shown by LibChecker. |
+| `details` | Yes | Object | In-app description and primary reference URL. |
+| `icon` | Yes | Object | Bundled SVG and its rendering behavior. |
+| `calculation` | Yes | `predicate` or `facets` | How apps are classified. |
+| `releaseChannel` | No | `stable` or `preview-only` | Controls which generated bundle includes the rule. Defaults to `stable`. |
+| `availability` | No | `always` | Availability gate. Schema v1 online rules only support `always`. |
+| `requiresFeatureInitialization` | No | Boolean | Hides the chart until feature initialization finishes. Defaults to `false`. |
+| `controls` | No | Empty array only | Online controls are not supported in schema v1. |
+| `dashboard` | No | `none` | Online dashboard integrations are not supported in schema v1. |
+| `fingerprint` | No | `standard`, `features`, or `artifact` | Selects the app-data fingerprint used to invalidate cached chart results. |
+
+JSON Schema `default` values document client defaults. The bundle builder does
+not insert missing optional fields into the generated catalog.
+
+### `id`
+
+The ID must match:
+
+```text
+^official\.[a-z0-9]+(?:[.-][a-z0-9]+)*$
+```
+
+Examples:
+
+- Valid: `official.flutter`, `official.android-api-level`,
+  `official.vendor.capability`.
+- Invalid: `flutter`, `official.Flutter`, `official_target_sdk`.
+
+Use a specific, technology-neutral ID. Once a rule has been published, never
+reuse its ID for a different statistic. The source filename should match the
+last ID segment, such as `official.flutter` in `flutter.json`.
+
+### `revision`
+
+Start a new rule at revision `1`. Increase the revision whenever a published
+rule changes its matching logic, titles, description, icon, calculation type,
+or other presentation metadata. A change to repository documentation alone
+does not require a rule revision.
+
+The revision belongs to one rule. It is independent of the generated bundle's
+`bundleVersion`.
+
+### `source`
+
+Every rule submitted to this repository must use:
+
+```json
+"source": "official"
+```
+
+The builder rejects other values.
+
+## Translated text
+
+`title`, `details.description`, predicate group titles, and facet titles use
+the same wrapper:
+
+```json
+{
+    "translations": {
+        "en": "English text",
+        "zh-Hans": "简体中文文本"
+    }
+}
+```
+
+### Translated-text parameters
+
+| Parameter | Type | Required | Allowed values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `translations` | Object | Yes | 2 to 16 locale entries; must include `en` and `zh-Hans` | Maps locale tags to the text shown by LibChecker. |
+| `translations.<locale>` | String | Yes for each declared locale | Non-empty; 80 characters for chart and group titles, 40 for facet titles, 1,500 for descriptions | Localized value for one BCP 47-style locale tag. |
+
+| Locale key | Allowed | Meaning |
+| --- | --- | --- |
+| `en` | Required | English text and runtime fallback. |
+| `zh-Hans` | Required | Simplified Chinese text. |
+| `zh`, `zh-CN` | Rejected | These tags are intentionally not accepted; use `zh-Hans`. |
+| Other schema-compatible tags | Optional | Additional translations, for example `pt-BR` or `es-419`, up to 16 locales total. |
+
+Rules for translations:
+
+- `en` and `zh-Hans` are required. English is the runtime fallback.
+- Use `zh-Hans` for Simplified Chinese. `zh` and `zh-CN` are rejected.
+- A translated object must contain 2 to 16 locales.
+- Locale keys use BCP 47-style tags accepted by the schema, such as `en`,
+  `zh-Hans`, `pt-BR`, or `es-419`.
+- Each translation must be a non-empty string.
+- `title`, `matchedTitle`, and `unmatchedTitle` allow up to 80 characters.
+- A facet `title` allows up to 40 characters because it is displayed as a chip.
+- `details.description` allows up to 1,500 characters.
+- Keep equivalent meaning across locales. Do not add claims to one language
+  that are absent from another.
+
+Use short labels for chart and group titles. The matched and unmatched titles
+name the two result groups, for example `Flutter apps` and `Other apps`.
+
+## Details and reference URL
+
+`details` is required:
+
+```json
+"details": {
+    "description": {
+        "translations": {
+            "en": "A neutral introduction to the technology.",
+            "zh-Hans": "对该技术的中性介绍。"
+        }
+    },
+    "referenceUrl": "https://project.example/documentation"
+}
+```
+
+### Details parameters
+
+| Parameter | Type | Required | Allowed values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `details.description` | Translated text | Yes | `en` and `zh-Hans`; 1 to 1,500 characters per locale | Neutral in-app introduction to the technology or capability. |
+| `details.referenceUrl` | String | Yes | HTTPS URL, valid host, no credentials or whitespace, maximum 512 characters | Primary source opened from the introduction dialog. |
+
+Write a short, neutral description of the technology or capability. Do not say
+that the currently selected app matches the rule. LibChecker appends the actual
+analysis result at runtime. Faceted rules also list the matched facet titles.
+
+`referenceUrl` must:
+
+- use HTTPS;
+- contain a valid host;
+- contain no username, password, or whitespace;
+- be no longer than 512 characters;
+- point to a primary project, standards body, vendor, or platform document.
+
+Do not use tracking links, URL shorteners, affiliate links, search results, or
+an unreviewed third-party summary.
+
+## Icons
+
+Every online rule references one repository asset:
+
+```json
+"icon": {
+    "asset": "icons/example-sdk.svg",
+    "renderMode": "monochrome",
+    "tintRole": "on_surface"
+}
+```
+
+### Icon fields
+
+| Field | Required | Allowed values | Meaning |
+| --- | --- | --- | --- |
+| `asset` | Yes | `icons/<safe-name>.svg` | Repository-relative path included in the bundle. |
+| `renderMode` | No | `monochrome`, `original` | Whether LibChecker applies a theme tint. Defaults to `monochrome`. |
+| `tintRole` | No | `on_surface`, `on_surface_variant`, `primary`, `secondary`, `tertiary` | Theme color used for a monochrome icon. Defaults to `on_surface`. |
+
+Use `original` only when the original brand colors carry meaning. LibChecker
+does not apply `tintRole` to an `original` icon. Use `monochrome` for a shape
+that should adapt to the active theme.
+
+### SVG requirements
+
+An SVG must:
+
+- use a `0 0 1024 1024` viewBox;
+- keep the artwork approximately within a centered `800 x 800` area so that
+  icons have consistent optical size;
+- remain below 64 KiB;
+- be valid UTF-8;
+- contain no scripts, styles, text nodes, linked images, entities, external
+  references, or `url(...)` content.
+
+The validator rejects `<!doctype`, `<!entity`, `<?xml-stylesheet`, `<script`,
+`<foreignObject`, `<image`, `<style`, `<text`, `href=`, `xlink:`, and `url(`.
+Convert text to paths and inline any required fill colors.
+
+## Choosing a calculation type
+
+Use `predicate` when every app belongs to one of two groups. Use `facets` when
+one app can match several named capabilities and the UI should show each match
+as a chip.
+
+| Question | Use |
+| --- | --- |
+| Does the app target SDK 35 or newer? | `predicate` |
+| Does the app contain `libflutter.so`? | `predicate` |
+| Which ITGSA capabilities does the app implement? | `facets` |
+
+### Calculation parameters
+
+| Parameter | Type | Required | Possible values | Meaning |
+| --- | --- | --- | --- | --- |
+| `calculation.kind` | String | Yes | `predicate`, `facets` | Selects the calculation object that must accompany it. |
+| `calculation.predicate` | Object | Required when `kind` is `predicate` | See [Predicate calculations](#predicate-calculations) | Produces matched and unmatched groups from one condition. |
+| `calculation.facets` | Object | Required when `kind` is `facets` | See [Facet calculations](#facet-calculations) | Produces matched and unmatched groups plus per-app capability chips. |
+
+Only the object selected by `kind` is allowed. Online rules cannot use the
+client's built-in `native` calculation type.
+
+Facets are for overlapping capabilities. Do not use them for mutually
+exclusive buckets or numeric distributions. Schema v1 has no online
+calculation type for those cases.
+
+## Predicate calculations
+
+A predicate requires `matchedTitle`, `unmatchedTitle`, and exactly one complete
+condition. For a single evidence leaf, put `evidence`, `operator`, and `value`
+directly in `predicate`:
+
+| Parameter | Type | Required | Possible values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `predicate.matchedTitle` | Translated text | Yes | 1 to 80 characters per locale | Label for apps whose condition evaluates to true. |
+| `predicate.unmatchedTitle` | Translated text | Yes | 1 to 80 characters per locale | Label for apps whose condition evaluates to false. |
+| `predicate.evidence` | String | Required for direct-leaf form | `target_sdk`, `native_library`, `dex_class`, `manifest_receiver_action` | Evidence provider used by the leaf. |
+| `predicate.operator` | String | Required for direct-leaf form | Depends on `evidence` | Comparison applied to the evidence. |
+| `predicate.value` | Object | Required for direct-leaf form | Exactly one value variant compatible with `evidence` | Expected value for the comparison. |
+| `predicate.condition` | Condition | Required for recursive form | One leaf, `all`, `any`, or `not` | Recursive condition used instead of the three direct-leaf fields. |
+
+```json
+"calculation": {
+    "kind": "predicate",
+    "predicate": {
+        "evidence": "target_sdk",
+        "operator": "greater_than_or_equal",
+        "value": {
+            "integer": 35
+        },
+        "matchedTitle": {
+            "translations": {
+                "en": "Target SDK 35 or newer",
+                "zh-Hans": "Target SDK 35 及以上"
+            }
+        },
+        "unmatchedTitle": {
+            "translations": {
+                "en": "Target SDK 34 or older",
+                "zh-Hans": "Target SDK 34 及以下"
+            }
+        }
+    }
+}
+```
+
+For logical composition, replace the direct leaf fields with one `condition`:
+
+```json
+"predicate": {
+    "condition": {
+        "any": [
+            {
+                "evidence": "native_library",
+                "operator": "contains",
+                "value": {
+                    "string": "libexample.so"
+                }
+            },
+            {
+                "evidence": "manifest_receiver_action",
+                "operator": "contains_any",
+                "value": {
+                    "strings": [
+                        "com.example.ACTION_READY"
+                    ]
+                }
+            }
+        ]
+    },
+    "matchedTitle": {
+        "translations": {
+            "en": "Example apps",
+            "zh-Hans": "示例应用"
+        }
+    },
+    "unmatchedTitle": {
+        "translations": {
+            "en": "Other apps",
+            "zh-Hans": "其他应用"
+        }
+    }
+}
+```
+
+Do not provide both the direct fields and `condition`. Partial direct tuples
+are also rejected.
+
+## Facet calculations
+
+A facet calculation contains 1 to 8 ordered items:
+
+| Parameter | Type | Required | Possible values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `facets.matchedTitle` | Translated text | Yes | 1 to 80 characters per locale | Chart label for apps matching at least one facet. |
+| `facets.unmatchedTitle` | Translated text | Yes | 1 to 80 characters per locale | Chart label for apps matching no facets. |
+| `facets.items` | Array | Yes | 1 to 8 facet objects | Ordered capability definitions. |
+| `items[].id` | String | Yes | Lowercase rule-local ID matching the documented pattern; unique within the rule | Stable internal identity of a facet. |
+| `items[].title` | Translated text | Yes | 1 to 40 characters per locale | Chip shown for a matching app. |
+| `items[].condition` | Condition | Yes | One leaf, `all`, `any`, or `not` | Determines whether this facet matches an app. |
+
+```json
+"calculation": {
+    "kind": "facets",
+    "facets": {
+        "matchedTitle": {
+            "translations": {
+                "en": "Example capability apps",
+                "zh-Hans": "示例能力应用"
+            }
+        },
+        "unmatchedTitle": {
+            "translations": {
+                "en": "Other apps",
+                "zh-Hans": "其他应用"
+            }
+        },
+        "items": [
+            {
+                "id": "service-kit",
+                "title": {
+                    "translations": {
+                        "en": "Service Kit",
+                        "zh-Hans": "服务套件"
+                    }
+                },
+                "condition": {
+                    "evidence": "native_library",
+                    "operator": "contains",
+                    "value": {
+                        "string": "libexample_service.so"
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+Each item requires:
+
+- a rule-local `id` matching
+  `^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$`;
+- a unique, stable ID within the rule;
+- a translated `title` of at most 40 characters per locale;
+- exactly one `condition`.
+
+An app enters the matched chart group when at least one facet matches. All
+matching facet titles are shown as chips in the order declared by `items`.
+Do not duplicate facet conditions in a separate root `any` expression.
+
+## Conditions
+
+A condition is either one typed evidence leaf or one logical operator.
+Additional properties are rejected.
+
+### Condition object parameters
+
+| Parameter | Type | Required | Possible values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `evidence` | String | Required for a leaf | `target_sdk`, `native_library`, `dex_class`, `manifest_receiver_action` | Selects the app data to inspect. |
+| `operator` | String | Required for a leaf | `equal`, `greater_than_or_equal`, `less_than_or_equal`, `contains`, `contains_any`; compatibility depends on `evidence` | Selects the comparison. |
+| `value` | Object | Required for a leaf | Exactly one of `integer`, `string`, `strings`, `dexClasses` | Supplies the expected value. |
+| `all` | Array of conditions | Required for an `all` node | 1 to 16 children | True when every child is true. |
+| `any` | Array of conditions | Required for an `any` node | 1 to 16 children | True when at least one child is true. |
+| `not` | Condition | Required for a `not` node | One child object | Inverts the child result. |
+
+Exactly one operation is allowed. A leaf must contain all of `evidence`,
+`operator`, and `value`; a logical node must contain only `all`, `any`, or
+`not`.
+
+### Value object parameters
+
+| Parameter | Type | Used by | Allowed values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `integer` | Integer | `target_sdk` | Any JSON integer | Numeric comparison target. |
+| `string` | String | `native_library` | 1 to 160 safe filename characters | Exact native-library filename. |
+| `strings` | Array of strings | `manifest_receiver_action` | 1 to 16 actions, each 1 to 160 safe action characters | Receiver actions; any listed action may match. |
+| `dexClasses` | Array of DEX class queries | `dex_class` | 1 to 16 queries | Class queries; any query may match. |
+
+One value object must contain exactly one of these parameters.
+
+### Evidence leaf
+
+```json
+{
+    "evidence": "native_library",
+    "operator": "contains",
+    "value": {
+        "string": "libflutter.so"
+    }
+}
+```
+
+All three fields are required and must use a compatible combination from the
+evidence table below.
+
+### Logical operators
+
+| Operator | Value | Result |
+| --- | --- | --- |
+| `all` | Array of 1 to 16 conditions | Matches when every child matches. |
+| `any` | Array of 1 to 16 conditions | Matches when at least one child matches. |
+| `not` | One condition object | Inverts the child result. |
+
+Example:
+
+```json
+{
+    "all": [
+        {
+            "evidence": "target_sdk",
+            "operator": "greater_than_or_equal",
+            "value": {
+                "integer": 35
+            }
+        },
+        {
+            "not": {
+                "evidence": "native_library",
+                "operator": "contains",
+                "value": {
+                    "string": "liblegacy.so"
+                }
+            }
+        }
+    ]
+}
+```
+
+### Condition limits
+
+- Maximum nesting depth: 8, with the root condition at depth 1.
+- Maximum condition nodes: 64 per predicate calculation. A facet rule shares
+  the same 64-node budget across all facet conditions.
+- Maximum children in one `all` or `any`: 16.
+- A condition object must define exactly one operation. It cannot mix a leaf
+  with `all`, `any`, or `not`.
+
+Prefer the narrowest condition that is supported by reliable evidence. A long
+condition is not necessarily a more accurate condition.
+
+## Evidence reference
+
+| Evidence | Operator | Value object | Match behavior |
+| --- | --- | --- | --- |
+| `target_sdk` | `equal`, `greater_than_or_equal`, `less_than_or_equal` | `{ "integer": <integer> }` | Compares the app's target SDK value. |
+| `native_library` | `contains` | `{ "string": "<library-name>" }` | Matches an exact native-library filename. |
+| `dex_class` | `contains_any` | `{ "dexClasses": [<query>, ...] }` | Matches when any query matches one DEX class. |
+| `manifest_receiver_action` | `contains_any` | `{ "strings": ["<action>", ...] }` | Matches when any listed action is declared by a manifest receiver. |
+
+### `target_sdk`
+
+The integer is compared with the target API recorded for the installed app.
+The schema does not impose an API-level range, but the value should represent a
+real Android API level.
+
+```json
+{
+    "evidence": "target_sdk",
+    "operator": "less_than_or_equal",
+    "value": {
+        "integer": 34
+    }
+}
+```
+
+Use `fingerprint: standard` or omit `fingerprint` for a rule that only depends
+on target SDK metadata.
+
+### `native_library`
+
+The value is an exact `.so` filename, not a path and not a regular expression.
+LibChecker checks extracted libraries and libraries packaged in the APK.
+
+```json
+{
+    "evidence": "native_library",
+    "operator": "contains",
+    "value": {
+        "string": "libflutter.so"
+    }
+}
+```
+
+The string must be 1 to 160 characters and may contain ASCII letters, digits,
+periods, underscores, plus signs, and hyphens. Use `fingerprint: artifact`.
+
+### `manifest_receiver_action`
+
+This evidence reads actions from manifest-declared broadcast receivers across
+the base and split APKs. It matches when at least one supplied action is found.
+
+```json
+{
+    "evidence": "manifest_receiver_action",
+    "operator": "contains_any",
+    "value": {
+        "strings": [
+            "com.example.ACTION_TRIM",
+            "com.example.ACTION_KILL"
+        ]
+    }
+}
+```
+
+The list must contain 1 to 16 strings. Each action must be 1 to 160 characters
+and may contain ASCII letters, digits, underscores, periods, and hyphens. Use
+`fingerprint: artifact`.
+
+### `dex_class`
+
+`dex_class` accepts 1 to 16 class queries. The outer `dexClasses` list is OR:
+the evidence matches when any query matches any class in the app's base or
+split APKs.
+
+```json
+{
+    "evidence": "dex_class",
+    "operator": "contains_any",
+    "value": {
+        "dexClasses": [
+            {
+                "name": {
+                    "operator": "starts_with",
+                    "value": "Lcom/example/sdk/"
+                },
+                "stringConstants": [
+                    "com.example.ACTION_READY"
+                ],
+                "methodReferences": [
+                    {
+                        "definingClass": "Landroid/content/IntentFilter;",
+                        "name": "addAction",
+                        "parameterTypes": [
+                            "Ljava/lang/String;"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+Each query may contain `name`, `stringConstants`, `methodReferences`, or a
+combination of them. At least one field is required.
+
+#### DEX class query parameters
+
+| Parameter | Type | Required | Allowed values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `name` | Object | No | `operator` plus `value` | Restricts the class descriptor. |
+| `stringConstants` | Array of strings | No | 1 to 16 strings, each 1 to 160 characters without control characters | Matches if the class references any listed string. |
+| `methodReferences` | Array of method-reference objects | No | 1 to 16 references | Matches if the class references any listed method. |
+
+At least one query parameter is required. If several parameters are present,
+all parameter categories must match the same class.
+
+The fields inside one query are AND categories and must be satisfied by the
+same DEX class:
+
+- `name`, when present, must match that class.
+- `stringConstants`, when present, succeeds if the class references any string
+  in the list.
+- `methodReferences`, when present, succeeds if the class references any method
+  in the list.
+
+For example, a query containing both `stringConstants` and `methodReferences`
+requires one class that contains at least one listed string and at least one
+listed method reference. The matching instructions do not have to appear in
+the same method. Use separate entries in `dexClasses` when the evidence may be
+found in different classes.
+
+Use `fingerprint: artifact` for every DEX rule.
+
+#### Class names
+
+DEX class names use descriptors, not Java or Kotlin dotted names.
+
+| Goal | Operator | Example |
+| --- | --- | --- |
+| Match one class | `equal` | `Lcom/example/sdk/EntryPoint;` |
+| Match a package or nested prefix | `starts_with` | `Lcom/example/sdk/` |
+
+| Name parameter | Type | Required | Possible values and limits | Meaning |
+| --- | --- | --- | --- | --- |
+| `name.operator` | String | Yes | `equal`, `starts_with` | Exact descriptor match or descriptor-prefix match. |
+| `name.value` | String | Yes | DEX class descriptor pattern beginning with `L`; `equal` must end in `;` | Descriptor or prefix to match. |
+
+`equal` requires the trailing semicolon. `starts_with` may omit it and usually
+uses a trailing slash for a package prefix. Values begin with `L` and may use
+letters, digits, underscores, dollar signs, slashes, and hyphens.
+
+#### String constants
+
+`stringConstants` contains 1 to 16 strings, each 1 to 160 characters. Control
+characters are rejected. These strings are literal DEX string references, not
+regular expressions or substrings.
+
+#### Method references
+
+A method reference requires `definingClass` and `name`:
+
+```json
+{
+    "definingClass": "Landroid/content/IntentFilter;",
+    "name": "<init>",
+    "parameterTypes": [
+        "Ljava/lang/String;"
+    ]
+}
+```
+
+| Field | Required | Constraint |
+| --- | --- | --- |
+| `definingClass` | Yes | Full DEX class descriptor ending in `;`, up to the schema limit. |
+| `name` | Yes | DEX method name, 1 to 80 characters. `<init>` and `<clinit>` are accepted. |
+| `parameterTypes` | No | Exact parameter descriptor list, at most 16 entries. |
+
+Omit `parameterTypes` to match any overload with the same defining class and
+method name. Provide it to require an exact parameter list. An empty array
+matches a zero-parameter method.
+
+Primitive descriptors are `Z` (boolean), `B` (byte), `S` (short), `C` (char),
+`I` (int), `J` (long), `F` (float), and `D` (double). Prefix a descriptor with
+`[` for each array dimension. Object types use full descriptors such as
+`Ljava/lang/String;`.
+
+## Optional metadata
+
+### `releaseChannel`
+
+- `stable` is the default and is included in both preview and stable bundles.
+- `preview-only` is included only when the builder uses `--channel preview`.
+
+The builder removes `releaseChannel` from the generated catalog. It is a
+repository publication control, not runtime chart metadata.
+
+### `availability`
+
+Schema v1 online rules only accept `always`, which is also the default. Omit
+this field unless a future schema adds a supported online availability gate.
+
+### `requiresFeatureInitialization`
+
+When `true`, LibChecker hides the chart until its feature initialization has
+finished. Current online evidence types do not require feature data, so new
+online rules should normally omit this field or use `false`.
+
+### `controls`
+
+Schema v1 allows no online chart controls. Omit this field. An explicit empty
+array is valid but adds no behavior.
+
+### `dashboard`
+
+Schema v1 online rules only accept `none`, which is the default. Omit it.
+
+### `fingerprint`
+
+The fingerprint controls when LibChecker discards cached chart results after
+installed-app data changes. It does not grant access to additional evidence.
+
+| Value | Use |
+| --- | --- |
+| `standard` | Metadata-based rules such as `target_sdk`. This is the default. |
+| `artifact` | Rules that inspect native libraries, DEX, or manifest contents. |
+| `features` | Rules that depend on LibChecker's initialized feature data. No schema v1 online evidence currently needs it. |
+
+Choose the fingerprint that covers every evidence leaf in the rule. A rule
+that combines target SDK with DEX evidence should use `artifact`.
+
+## Validation and tests
+
+Run:
+
+```shell
+python3 -m unittest chart.tools.test_build_bundle
+```
+
+The JSON Schema defines the complete object shape and field constraints. The
+Python builder performs additional semantic validation. It rejects incompatible
+evidence/operator/value combinations, unsafe URLs, unsafe icon paths and SVG
+content, duplicate IDs, duplicate facet IDs, and complexity-limit violations.
+
+When adding a rule, update the existing assertions in
+`chart/tools/test_build_bundle.py`:
+
+1. Add the ID in sorted order to `test_source_rules_are_valid`.
+2. Add a new icon path in sorted archive order and update the expected catalog
+   count in `test_bundle_is_deterministic_and_contains_only_expected_files`.
+3. Update `test_stable_bundle_excludes_preview_only_rules` according to the
+   rule's release channel.
+4. Add one focused test that asserts the important detection values, condition
+   ordering, icon render mode, details URL, or another property that reviewers
+   should not accidentally change.
+5. Add negative validation tests when you introduce a new schema capability or
+   validator branch.
+
+Do not weaken limits or delete regression assertions only to make a new rule
+pass.
+
+## Bundle generation
+
+For a local preview, write to a temporary directory so that validation does not
+modify tracked generated files:
+
+```shell
+python3 chart/tools/build_bundle.py \
+  --bundle-version 12 \
+  --channel preview \
+  --minimum-app-version-code 2731 \
+  --output-dir /tmp/libchecker-chart-preview
+```
+
+For the final branch artifact, omit `--output-dir` to write to `chart/cloud/v1/`:
+
+```shell
+python3 chart/tools/build_bundle.py \
+  --bundle-version 12 \
+  --channel preview \
+  --minimum-app-version-code 2731
+```
+
+Builder arguments:
+
+| Argument | Required | Meaning |
+| --- | --- | --- |
+| `--bundle-version` | Yes | Positive, monotonically increasing publication version for the target branch. |
+| `--channel` | No | `preview` by default, or `stable`. Preview includes both release channels; stable excludes `preview-only`. |
+| `--minimum-app-version-code` | No | First LibChecker version code that can safely load every rule in the bundle. Defaults to `0`, which should only be published when all supported clients are compatible. |
+| `--output-dir` | No | Destination directory. Defaults to `chart/cloud/v1/`. |
+
+If the rule uses only evidence and calculation features already supported by
+the published app, retain the branch's compatible minimum app version. If it
+depends on a new client capability, coordinate the app change first and set the
+exact first compatible version code. Do not guess this number.
+
+The builder:
+
+- validates every source rule and referenced SVG;
+- sorts rules by ID and icons by path;
+- writes a deterministic ZIP containing `catalog.json` and referenced icons;
+- limits the bundle to 64 rules and 2 MiB;
+- computes `bundleSha256` and `bundleSize`;
+- writes `manifest.json` with schema, publication, and compatibility metadata.
+
+Commit `chart.bundle` and `manifest.json` together. A checksum or size from one
+generation cannot be paired with a bundle from another generation.
+
+## Manual verification
+
+Automated validation proves that a rule is well-formed. It does not prove that
+the evidence identifies the intended apps.
+
+Before requesting stable publication:
+
+1. Install a compatible LibChecker build that reads the preview branch.
+2. Check at least one known matching app and one known non-matching app.
+3. For facets, verify every facet independently and confirm that an app matching
+   several facets shows all expected chips in rule order.
+4. Check the chart title, group titles, description, reference link, icon size,
+   colors, light theme, and dark theme.
+5. Record the app versions or sample APKs used for testing in the PR description.
+6. Rebuild with `--channel stable` and inspect the catalog before publishing.
+   Every `preview-only` rule must be absent.
+
+## Pull request checklist
+
+- [ ] The rule solves one clearly described statistic.
+- [ ] The ID and filename are stable and follow the naming rules.
+- [ ] A new rule starts at revision `1`; an edited published rule increments its revision.
+- [ ] All text includes equivalent `en` and `zh-Hans` translations.
+- [ ] The description is neutral and the HTTPS reference is primary.
+- [ ] The calculation uses only supported evidence and compatible operators.
+- [ ] DEX queries use descriptors and preserve same-class matching semantics.
+- [ ] The SVG passes the safety and viewBox requirements.
+- [ ] The release channel and fingerprint match the rule's maturity and evidence.
+- [ ] Focused tests cover the important matching data and channel behavior.
+- [ ] Unit tests pass.
+- [ ] Matching and non-matching apps were checked with a compatible LibChecker build.
+- [ ] The generated bundle and manifest were rebuilt and committed together.
+
+## Recovery after a bad publication
+
+Do not reuse an older bundle version. Restore the last known-good source rules
+and generated contents, then publish them with a higher `bundleVersion`.
+Compatible LibChecker clients retain their cached bundle when a download,
+checksum, schema, or minimum-version check fails.

--- a/chart/README.zh-Hans.md
+++ b/chart/README.zh-Hans.md
@@ -1,0 +1,853 @@
+# 图表规则贡献指南
+
+[English](README.md) | 简体中文
+
+本目录存放 LibChecker 图表页面使用的声明式统计规则。规则负责描述需要检查的数据、判定匹配的条件，以及向用户显示的标题、说明和图标。
+
+规则不能执行脚本或任意代码。APK、DEX、Manifest 和原生文件的遍历都由 LibChecker 实现。规则只能组合当前客户端已经支持的证据类型和操作符。
+
+## 开始之前
+
+编写 JSON 前，请先确认以下问题：
+
+1. 这个图表统计什么，它对 LibChecker 用户有什么作用？
+2. 已安装应用中的哪类证据能够证明匹配？
+3. 每个应用只会得到“匹配或不匹配”的结果，还是可能同时匹配多项能力？
+4. 是否有介绍该技术或能力的 HTTPS 一手资料？
+5. 是否有已知匹配和不匹配的 APK 可用于验证？
+
+Schema v1 只能使用[证据类型参考](#证据类型参考)中列出的证据。如果规则需要 DEX 字段、资源表条目、原生符号、证书属性或任意文件内容等新数据，请先在 LibChecker 客户端中设计并实现通用的证据提供器，不要在规则中绕过这一限制。
+
+新规则通常应先设置 `"releaseChannel": "preview-only"`。使用兼容的 LibChecker 版本完成预览验证后，再将规则发布到稳定渠道。
+
+## 提交流程
+
+1. Fork 本仓库并创建独立分支。
+2. 从 `rules/` 中选择最接近的示例：
+   - 精确匹配原生库参考 [`flutter.json`](rules/flutter.json)。
+   - Facet、递归条件、DEX 查询和 Manifest Receiver Action 参考 [`itgsa.json`](rules/itgsa.json)。
+   - 数值比较参考下文的 [Predicate 示例](#predicate-计算)。
+3. 在 `rules/` 下新增一个 UTF-8 JSON 文件。使用四个空格缩进，文件名与规则 ID 的最后一段保持一致。
+4. 在 `icons/` 下添加规则引用的 SVG。
+5. 更新测试中的规则 ID、图标、Catalog 数量和稳定渠道内容，并为新规则的关键判定数据添加专门断言。
+6. 运行单元测试，并将预览 Bundle 生成到临时目录。
+7. 使用已知匹配和不匹配的应用验证预览规则。
+8. 按照目标分支确定的 Bundle 版本和最低应用版本，重新生成 `cloud/v1/chart.bundle` 与 `cloud/v1/manifest.json`。
+9. 在同一个 Pull Request 中提交源规则、图标、测试、生成的 Bundle 和 Manifest。PR 描述中应写明证据来源与人工测试结果。
+
+从仓库根目录运行：
+
+```shell
+python3 -m unittest chart.tools.test_build_bundle
+python3 chart/tools/build_bundle.py \
+  --bundle-version 12 \
+  --channel preview \
+  --minimum-app-version-code 2731 \
+  --output-dir /tmp/libchecker-chart-preview
+```
+
+上面的数字只是示例。选择 Bundle 版本或最低应用版本前，请先检查 `chart/cloud/v1/manifest.json` 和目标分支的发布状态。
+
+## 目录结构
+
+| 路径 | 用途 |
+| --- | --- |
+| `rules/` | 经过审核的源规则，每个统计项对应一个 JSON 文件。 |
+| `icons/` | 源规则引用的 SVG 图标。 |
+| `schema/v1/chart-rule.schema.json` | 源规则的机器可读 Schema。 |
+| `schema/v1/manifest.schema.json` | 生成后 Manifest 的机器可读 Schema。 |
+| `tools/build_bundle.py` | 校验器和确定性 Bundle 生成器。 |
+| `tools/test_build_bundle.py` | 源规则校验与 Bundle 回归测试。 |
+| `cloud/v1/chart.bundle` | LibChecker 使用的已生成 Catalog 与图标。 |
+| `cloud/v1/manifest.json` | 已生成的版本、兼容性、大小和校验和信息。 |
+
+## 最小完整规则
+
+以下示例包含一个完整的单条件规则：
+
+```json
+{
+    "id": "official.example-sdk",
+    "revision": 1,
+    "source": "official",
+    "releaseChannel": "preview-only",
+    "title": {
+        "translations": {
+            "en": "Example SDK",
+            "zh-Hans": "示例 SDK"
+        }
+    },
+    "details": {
+        "description": {
+            "translations": {
+                "en": "Example SDK provides a documented capability for Android apps.",
+                "zh-Hans": "示例 SDK 为 Android 应用提供一项有公开文档的能力。"
+            }
+        },
+        "referenceUrl": "https://example.com/android-sdk"
+    },
+    "icon": {
+        "asset": "icons/example-sdk.svg",
+        "renderMode": "monochrome",
+        "tintRole": "on_surface"
+    },
+    "calculation": {
+        "kind": "predicate",
+        "predicate": {
+            "evidence": "native_library",
+            "operator": "contains",
+            "value": {
+                "string": "libexample.so"
+            },
+            "matchedTitle": {
+                "translations": {
+                    "en": "Example SDK apps",
+                    "zh-Hans": "示例 SDK 应用"
+                }
+            },
+            "unmatchedTitle": {
+                "translations": {
+                    "en": "Other apps",
+                    "zh-Hans": "其他应用"
+                }
+            }
+        }
+    },
+    "fingerprint": "artifact"
+}
+```
+
+## 顶层参数
+
+源规则 Schema 不允许出现未定义的字段。官方在线规则可以使用以下顶层参数。
+
+| 参数 | 是否必填 | 类型或全部可选值 | 默认值 | 含义 |
+| --- | --- | --- | --- | --- |
+| `id` | 是 | 符合 `official.<name>` 格式的字符串 | 无 | 统计规则的永久标识。 |
+| `revision` | 是 | 不小于 `1` 的整数 | 无 | 当前规则定义的修订号。 |
+| `source` | 是 | `official` | 无 | 本仓库在线规则的来源类型。 |
+| `title` | 是 | 多语言文本对象 | 无 | LibChecker 显示的图表标题。 |
+| `details` | 是 | 对象 | 无 | 应用内说明与一手资料链接。 |
+| `icon` | 是 | 对象 | 无 | Bundle 内的 SVG 及其渲染方式。 |
+| `calculation` | 是 | `predicate`、`facets` | 无 | 应用的分类方式。 |
+| `releaseChannel` | 否 | `stable`、`preview-only` | `stable` | 决定规则进入哪些渠道的 Bundle。 |
+| `availability` | 否 | `always` | `always` | 可用性限制。Schema v1 在线规则只支持始终可用。 |
+| `requiresFeatureInitialization` | 否 | `true`、`false` | `false` | 是否在特征初始化完成前隐藏图表。 |
+| `controls` | 否 | 只能是空数组 `[]` | `[]` | Schema v1 不支持在线图表控件。 |
+| `dashboard` | 否 | `none` | `none` | Schema v1 不支持在线 Dashboard 集成。 |
+| `fingerprint` | 否 | `standard`、`features`、`artifact` | `standard` | 用于判断图表缓存是否失效的应用数据指纹。 |
+
+JSON Schema 中的 `default` 用于说明客户端默认行为。Bundle 生成器不会把缺少的可选字段自动写入 Catalog。
+
+### `id`
+
+ID 必须符合：
+
+```text
+^official\.[a-z0-9]+(?:[.-][a-z0-9]+)*$
+```
+
+| 示例 | 是否有效 | 原因 |
+| --- | --- | --- |
+| `official.flutter` | 是 | 使用 `official.` 前缀和小写名称。 |
+| `official.android-api-level` | 是 | 可以使用小写字母、数字、连字符和分段点号。 |
+| `official.vendor.capability` | 是 | 可以包含多个点号分段。 |
+| `flutter` | 否 | 缺少 `official.` 前缀。 |
+| `official.Flutter` | 否 | 包含大写字母。 |
+| `official_target_sdk` | 否 | 格式不符合要求。 |
+
+ID 应具体且不依赖容易变化的展示文案。规则发布后，不得将原 ID 用于另一项统计。源文件名应与 ID 最后一段一致，例如 `official.flutter` 使用 `flutter.json`。
+
+### `revision`
+
+| 场景 | 修订号处理 |
+| --- | --- |
+| 新规则 | 从 `1` 开始。 |
+| 修改已发布规则的判定逻辑 | 加 `1`。 |
+| 修改标题、说明、图标、计算类型或其他展示元数据 | 加 `1`。 |
+| 只修改仓库文档，不改变规则 | 不需要修改。 |
+
+`revision` 属于单条规则，与生成 Bundle 的 `bundleVersion` 相互独立。
+
+### `source`
+
+本仓库中的每条规则都必须使用：
+
+```json
+"source": "official"
+```
+
+其他值会被生成器拒绝。
+
+## 多语言文本
+
+`title`、`details.description`、Predicate 分组标题和 Facet 标题使用同一种结构：
+
+```json
+{
+    "translations": {
+        "en": "English text",
+        "zh-Hans": "简体中文文本"
+    }
+}
+```
+
+### 多语言文本参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `translations` | 对象 | 是 | 2 至 16 个语言项，必须包含 `en` 和 `zh-Hans` | 语言标签到显示文本的映射。 |
+| `translations.<locale>` | 字符串 | 每个已声明语言都必填 | 不能为空；图表和分组标题最多 80 个字符，Facet 标题最多 40 个字符，说明最多 1,500 个字符 | 指定语言的本地化文本。 |
+
+| 语言标签 | 是否允许 | 含义 |
+| --- | --- | --- |
+| `en` | 必填 | 英文，也是运行时回退语言。 |
+| `zh-Hans` | 必填 | 简体中文。 |
+| `zh`、`zh-CN` | 禁止 | 必须改用 `zh-Hans`。 |
+| 其他符合 Schema 的标签 | 可选 | 可以添加 `pt-BR`、`es-419` 等翻译，总数不能超过 16。 |
+
+不同语言应表达相同含义，不能只在某一种语言中增加事实或宣传性断言。图表标题和分组标题应尽量简短。`matchedTitle` 与 `unmatchedTitle` 分别命名匹配和不匹配的两组结果，例如“Flutter 应用”和“其他应用”。
+
+## 详情与参考链接
+
+`details` 为必填对象：
+
+```json
+"details": {
+    "description": {
+        "translations": {
+            "en": "A neutral introduction to the technology.",
+            "zh-Hans": "对该技术的中性介绍。"
+        }
+    },
+    "referenceUrl": "https://project.example/documentation"
+}
+```
+
+### 详情参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `details.description` | 多语言文本 | 是 | 必须包含 `en` 和 `zh-Hans`，每种语言 1 至 1,500 个字符 | 对技术或能力的中性介绍。 |
+| `details.referenceUrl` | 字符串 | 是 | HTTPS URL，必须有有效 Host，不得包含账号、密码或空白，最多 512 个字符 | 详情对话框中打开的一手资料。 |
+
+说明只介绍技术或能力本身，不要声称当前选中的应用已经匹配。LibChecker 会在运行时追加实际分析结果。Facet 规则还会列出匹配到的 Facet 标题。
+
+参考链接应指向项目官网、标准组织、供应商或平台的一手文档。不要使用追踪链接、短链接、推广链接、搜索结果或未经审核的第三方摘要。
+
+## 图标
+
+每条在线规则都要引用仓库中的一个 SVG：
+
+```json
+"icon": {
+    "asset": "icons/example-sdk.svg",
+    "renderMode": "monochrome",
+    "tintRole": "on_surface"
+}
+```
+
+### 图标参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值 | 默认值 | 含义 |
+| --- | --- | --- | --- | --- | --- |
+| `icon.asset` | 字符串 | 是 | `icons/<safe-name>.svg` | 无 | 会被打包进 Bundle 的仓库相对路径。 |
+| `icon.renderMode` | 字符串 | 否 | `monochrome`、`original` | `monochrome` | 决定 LibChecker 是否应用主题着色。 |
+| `icon.tintRole` | 字符串 | 否 | `on_surface`、`on_surface_variant`、`primary`、`secondary`、`tertiary` | `on_surface` | 单色图标使用的主题颜色。 |
+
+| `renderMode` 值 | 渲染行为 | `tintRole` 是否生效 | 适用场景 |
+| --- | --- | --- | --- |
+| `monochrome` | LibChecker 使用主题颜色统一着色。 | 是 | 应随浅色或深色主题变化的单色轮廓。 |
+| `original` | 保留 SVG 自带颜色。 | 否 | 品牌颜色具有识别意义的图标。 |
+
+### SVG 要求
+
+| 项目 | 限制 |
+| --- | --- |
+| `viewBox` | 必须是 `0 0 1024 1024`。 |
+| 视觉边界 | 图形应大致位于居中的 `800 x 800` 区域，保持不同图标的视觉尺寸一致。 |
+| 文件大小 | 小于 64 KiB。 |
+| 编码 | 有效 UTF-8。 |
+| 外部内容 | 禁止脚本、样式、文本节点、链接图片、实体、外部引用和 `url(...)`。 |
+
+校验器会拒绝 `<!doctype`、`<!entity`、`<?xml-stylesheet`、`<script`、`<foreignObject`、`<image`、`<style`、`<text`、`href=`、`xlink:` 和 `url(`。请将文字转换为路径，并直接写入需要保留的填充颜色。
+
+## 选择计算类型
+
+应用只能落入匹配或不匹配两组时使用 `predicate`。一个应用可能同时匹配多项能力，并且界面需要显示每项能力的 Chip 时使用 `facets`。
+
+| 统计问题 | 应使用的类型 |
+| --- | --- |
+| 应用是否以 SDK 35 或更高版本为目标？ | `predicate` |
+| 应用是否包含 `libflutter.so`？ | `predicate` |
+| 应用实现了哪些金标联盟开放能力？ | `facets` |
+
+### `calculation` 参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值 | 含义 |
+| --- | --- | --- | --- | --- |
+| `calculation.kind` | 字符串 | 是 | `predicate`、`facets` | 决定必须同时提供哪一种计算对象。 |
+| `calculation.predicate` | 对象 | `kind` 为 `predicate` 时必填 | 见 [Predicate 计算](#predicate-计算) | 根据一个条件生成匹配组和不匹配组。 |
+| `calculation.facets` | 对象 | `kind` 为 `facets` 时必填 | 见 [Facet 计算](#facet-计算) | 除了匹配和不匹配分组，还会生成每个应用的能力 Chip。 |
+
+只能提供 `kind` 选中的对象。在线规则不能使用客户端内置规则所使用的 `native` 计算类型。
+
+Facet 用于可以重叠的能力，不适用于互斥分桶或数值分布。Schema v1 暂时没有支持这些场景的在线计算类型。
+
+## Predicate 计算
+
+Predicate 必须包含 `matchedTitle`、`unmatchedTitle` 和一个完整条件。
+
+### `predicate` 参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `predicate.matchedTitle` | 多语言文本 | 是 | 每种语言 1 至 80 个字符 | 条件结果为真的应用分组名称。 |
+| `predicate.unmatchedTitle` | 多语言文本 | 是 | 每种语言 1 至 80 个字符 | 条件结果为假的应用分组名称。 |
+| `predicate.evidence` | 字符串 | 直接叶子写法必填 | `target_sdk`、`native_library`、`dex_class`、`manifest_receiver_action` | 叶子条件使用的证据。 |
+| `predicate.operator` | 字符串 | 直接叶子写法必填 | 取决于 `evidence` | 应用于证据的比较操作。 |
+| `predicate.value` | 对象 | 直接叶子写法必填 | 只能包含一种与 `evidence` 兼容的值 | 比较所需的目标值。 |
+| `predicate.condition` | Condition 对象 | 递归写法必填 | 一个证据叶子、`all`、`any` 或 `not` | 代替三个直接叶子字段的递归条件。 |
+
+单个证据叶子可以直接放在 `predicate` 中：
+
+```json
+"calculation": {
+    "kind": "predicate",
+    "predicate": {
+        "evidence": "target_sdk",
+        "operator": "greater_than_or_equal",
+        "value": {
+            "integer": 35
+        },
+        "matchedTitle": {
+            "translations": {
+                "en": "Target SDK 35 or newer",
+                "zh-Hans": "Target SDK 35 及以上"
+            }
+        },
+        "unmatchedTitle": {
+            "translations": {
+                "en": "Target SDK 34 or older",
+                "zh-Hans": "Target SDK 34 及以下"
+            }
+        }
+    }
+}
+```
+
+需要组合逻辑时，用一个 `condition` 取代直接叶子的三个字段：
+
+```json
+"predicate": {
+    "condition": {
+        "any": [
+            {
+                "evidence": "native_library",
+                "operator": "contains",
+                "value": {
+                    "string": "libexample.so"
+                }
+            },
+            {
+                "evidence": "manifest_receiver_action",
+                "operator": "contains_any",
+                "value": {
+                    "strings": [
+                        "com.example.ACTION_READY"
+                    ]
+                }
+            }
+        ]
+    },
+    "matchedTitle": {
+        "translations": {
+            "en": "Example apps",
+            "zh-Hans": "示例应用"
+        }
+    },
+    "unmatchedTitle": {
+        "translations": {
+            "en": "Other apps",
+            "zh-Hans": "其他应用"
+        }
+    }
+}
+```
+
+直接叶子字段与 `condition` 不能同时出现，三个直接叶子字段也不能只提供一部分。
+
+## Facet 计算
+
+Facet 计算包含 1 至 8 个有顺序的条目。
+
+### `facets` 参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `facets.matchedTitle` | 多语言文本 | 是 | 每种语言 1 至 80 个字符 | 至少匹配一个 Facet 的应用分组名称。 |
+| `facets.unmatchedTitle` | 多语言文本 | 是 | 每种语言 1 至 80 个字符 | 没有匹配任何 Facet 的应用分组名称。 |
+| `facets.items` | 数组 | 是 | 1 至 8 个 Facet 对象 | 按界面展示顺序排列的能力定义。 |
+| `items[].id` | 字符串 | 是 | 符合规定格式的小写局部 ID，在规则内唯一 | Facet 的稳定内部标识。 |
+| `items[].title` | 多语言文本 | 是 | 每种语言 1 至 40 个字符 | 应用匹配后显示的 Chip 文案。 |
+| `items[].condition` | Condition 对象 | 是 | 一个证据叶子、`all`、`any` 或 `not` | 判断当前 Facet 是否匹配。 |
+
+```json
+"calculation": {
+    "kind": "facets",
+    "facets": {
+        "matchedTitle": {
+            "translations": {
+                "en": "Example capability apps",
+                "zh-Hans": "示例能力应用"
+            }
+        },
+        "unmatchedTitle": {
+            "translations": {
+                "en": "Other apps",
+                "zh-Hans": "其他应用"
+            }
+        },
+        "items": [
+            {
+                "id": "service-kit",
+                "title": {
+                    "translations": {
+                        "en": "Service Kit",
+                        "zh-Hans": "服务套件"
+                    }
+                },
+                "condition": {
+                    "evidence": "native_library",
+                    "operator": "contains",
+                    "value": {
+                        "string": "libexample_service.so"
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+Facet ID 必须符合 `^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$`。ID 在当前规则中必须唯一，发布后应保持稳定。
+
+应用至少匹配一个 Facet 时会进入图表的匹配组。所有命中的 Facet 标题都会按照 `items` 中的声明顺序显示为 Chip。不要再用一个根 `any` 重复 Facet 条件，否则会产生两份判定来源。
+
+## Condition 条件
+
+Condition 对象只能是一个带类型的证据叶子，或者一个逻辑操作。未定义字段会被拒绝。
+
+### Condition 对象参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `evidence` | 字符串 | 叶子条件必填 | `target_sdk`、`native_library`、`dex_class`、`manifest_receiver_action` | 选择要检查的应用数据。 |
+| `operator` | 字符串 | 叶子条件必填 | `equal`、`greater_than_or_equal`、`less_than_or_equal`、`contains`、`contains_any`，具体兼容性取决于 `evidence` | 选择比较方式。 |
+| `value` | 对象 | 叶子条件必填 | 只能包含 `integer`、`string`、`strings`、`dexClasses` 中的一个 | 提供比较目标。 |
+| `all` | Condition 数组 | `all` 节点必填 | 1 至 16 个子条件 | 所有子条件都为真时匹配。 |
+| `any` | Condition 数组 | `any` 节点必填 | 1 至 16 个子条件 | 至少一个子条件为真时匹配。 |
+| `not` | Condition 对象 | `not` 节点必填 | 一个子条件 | 对子条件结果取反。 |
+
+一个对象只能定义一种操作。证据叶子必须同时包含 `evidence`、`operator` 和 `value`。逻辑节点只能包含 `all`、`any` 或 `not` 中的一个。
+
+### `value` 对象参数
+
+| 参数 | 类型 | 对应证据 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `integer` | 整数 | `target_sdk` | 任意 JSON 整数 | 数值比较目标。 |
+| `string` | 字符串 | `native_library` | 1 至 160 个安全文件名字符 | 精确的原生库文件名。 |
+| `strings` | 字符串数组 | `manifest_receiver_action` | 1 至 16 个 Action，每项 1 至 160 个安全字符 | Receiver Action 列表，任意一项可以匹配。 |
+| `dexClasses` | DEX Class Query 数组 | `dex_class` | 1 至 16 个查询 | 类查询列表，任意一个查询可以匹配。 |
+
+一个 `value` 对象只能包含上述参数中的一个。
+
+### 逻辑操作符
+
+| 操作符 | 值 | 匹配语义 |
+| --- | --- | --- |
+| `all` | 1 至 16 个 Condition | 所有子条件匹配时为真。 |
+| `any` | 1 至 16 个 Condition | 至少一个子条件匹配时为真。 |
+| `not` | 一个 Condition | 将子条件结果取反。 |
+
+```json
+{
+    "all": [
+        {
+            "evidence": "target_sdk",
+            "operator": "greater_than_or_equal",
+            "value": {
+                "integer": 35
+            }
+        },
+        {
+            "not": {
+                "evidence": "native_library",
+                "operator": "contains",
+                "value": {
+                    "string": "liblegacy.so"
+                }
+            }
+        }
+    ]
+}
+```
+
+### 条件复杂度限制
+
+| 限制项 | 最大值 | 计算方式 |
+| --- | --- | --- |
+| 嵌套深度 | 8 | 根 Condition 的深度为 1。 |
+| Condition 节点总数 | 64 | Predicate 单独计算；Facet 规则的所有 Facet 共用 64 个节点。 |
+| 单个 `all` 或 `any` 的子条件数 | 16 | 每个数组至少包含 1 项。 |
+
+应使用有可靠依据的最窄条件。条件更长不等于误报率更低。
+
+## 证据类型参考
+
+| `evidence` | 唯一兼容的 `operator` | `value` 结构 | 匹配语义 |
+| --- | --- | --- | --- |
+| `target_sdk` | `equal`、`greater_than_or_equal`、`less_than_or_equal` | `{ "integer": <整数> }` | 比较应用的 Target SDK。 |
+| `native_library` | `contains` | `{ "string": "<库文件名>" }` | 精确匹配原生库文件名。 |
+| `dex_class` | `contains_any` | `{ "dexClasses": [<查询>, ...] }` | 任意查询匹配任意一个 DEX 类时为真。 |
+| `manifest_receiver_action` | `contains_any` | `{ "strings": ["<action>", ...] }` | Manifest Receiver 声明任意一个 Action 时为真。 |
+
+### `target_sdk`
+
+| 参数 | 值 |
+| --- | --- |
+| `evidence` | `target_sdk` |
+| `operator` | `equal`、`greater_than_or_equal`、`less_than_or_equal` |
+| `value` | 只包含一个 `integer` |
+| 推荐 `fingerprint` | `standard`，也可以省略并使用默认值 |
+
+整数会与已安装应用记录的 Target API 比较。Schema 没有限制 API Level 的范围，但提交的值应当对应真实的 Android API Level。
+
+```json
+{
+    "evidence": "target_sdk",
+    "operator": "less_than_or_equal",
+    "value": {
+        "integer": 34
+    }
+}
+```
+
+### `native_library`
+
+| 参数 | 值 |
+| --- | --- |
+| `evidence` | `native_library` |
+| `operator` | 只能是 `contains` |
+| `value.string` | 1 至 160 个字符，只允许 ASCII 字母、数字、`.`、`_`、`+`、`-` |
+| 推荐 `fingerprint` | `artifact` |
+
+值是精确的 `.so` 文件名，不是路径、正则表达式或子串。LibChecker 会检查已解压的原生库和 APK 内打包的原生库。
+
+```json
+{
+    "evidence": "native_library",
+    "operator": "contains",
+    "value": {
+        "string": "libflutter.so"
+    }
+}
+```
+
+### `manifest_receiver_action`
+
+| 参数 | 值 |
+| --- | --- |
+| `evidence` | `manifest_receiver_action` |
+| `operator` | 只能是 `contains_any` |
+| `value.strings` | 1 至 16 项，每项 1 至 160 个字符，只允许 ASCII 字母、数字、`_`、`.`、`-` |
+| 推荐 `fingerprint` | `artifact` |
+
+该证据读取 Base APK 和 Split APK 中由 Manifest 声明的 Broadcast Receiver Action。列表中至少一个 Action 存在时即为匹配。
+
+```json
+{
+    "evidence": "manifest_receiver_action",
+    "operator": "contains_any",
+    "value": {
+        "strings": [
+            "com.example.ACTION_TRIM",
+            "com.example.ACTION_KILL"
+        ]
+    }
+}
+```
+
+### `dex_class`
+
+| 参数 | 值 |
+| --- | --- |
+| `evidence` | `dex_class` |
+| `operator` | 只能是 `contains_any` |
+| `value.dexClasses` | 1 至 16 个 DEX Class Query |
+| 推荐 `fingerprint` | `artifact` |
+
+`dexClasses` 数组使用 OR 语义。Base APK 或 Split APK 中的任意类满足任意一个 Query 时，整个证据即为匹配。
+
+```json
+{
+    "evidence": "dex_class",
+    "operator": "contains_any",
+    "value": {
+        "dexClasses": [
+            {
+                "name": {
+                    "operator": "starts_with",
+                    "value": "Lcom/example/sdk/"
+                },
+                "stringConstants": [
+                    "com.example.ACTION_READY"
+                ],
+                "methodReferences": [
+                    {
+                        "definingClass": "Landroid/content/IntentFilter;",
+                        "name": "addAction",
+                        "parameterTypes": [
+                            "Ljava/lang/String;"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+#### DEX Class Query 参数
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 匹配语义 |
+| --- | --- | --- | --- | --- |
+| `name` | 对象 | 否 | 包含 `operator` 与 `value` | 限制类描述符。 |
+| `stringConstants` | 字符串数组 | 否 | 1 至 16 项，每项 1 至 160 个无控制字符的字符串 | 当前类引用任意一个字符串时满足该项。 |
+| `methodReferences` | Method Reference 数组 | 否 | 1 至 16 项 | 当前类引用任意一个方法时满足该项。 |
+
+每个 Query 至少要有一个参数。一个 Query 同时出现多个参数时，所有参数类别必须由同一个 DEX 类满足：
+
+- 有 `name` 时，类名必须匹配。
+- 有 `stringConstants` 时，该类至少引用列表中的一个字符串。
+- 有 `methodReferences` 时，该类至少引用列表中的一个方法。
+
+例如，同时包含 `stringConstants` 和 `methodReferences` 的 Query，要求同一个类至少引用一个目标字符串和一个目标方法，但两条引用指令不要求位于同一个方法体中。证据可能出现在不同类时，应拆成多个 `dexClasses` 数组项。
+
+#### 类名参数
+
+DEX 类名使用描述符，不使用 Java 或 Kotlin 的点分名称。
+
+| `name` 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `name.operator` | 字符串 | 是 | `equal`、`starts_with` | 精确匹配类描述符，或匹配描述符前缀。 |
+| `name.value` | 字符串 | 是 | 以 `L` 开头的 DEX 类描述符模式；`equal` 必须以 `;` 结尾 | 需要匹配的完整描述符或前缀。 |
+
+| 目标 | `operator` | 示例 |
+| --- | --- | --- |
+| 匹配一个类 | `equal` | `Lcom/example/sdk/EntryPoint;` |
+| 匹配一个包或嵌套前缀 | `starts_with` | `Lcom/example/sdk/` |
+
+类名可以使用字母、数字、下划线、美元符号、斜杠和连字符。`starts_with` 可以省略分号，匹配包前缀时通常以斜杠结尾。
+
+#### 字符串常量参数
+
+| 参数 | 类型 | 数量 | 单项长度 | 其他限制 |
+| --- | --- | --- | --- | --- |
+| `stringConstants` | 字符串数组 | 1 至 16 | 1 至 160 个字符 | 禁止控制字符；按 DEX 中的完整字符串引用匹配，不支持正则或子串。 |
+
+#### 方法引用参数
+
+```json
+{
+    "definingClass": "Landroid/content/IntentFilter;",
+    "name": "<init>",
+    "parameterTypes": [
+        "Ljava/lang/String;"
+    ]
+}
+```
+
+| 参数 | 类型 | 是否必填 | 全部可选值与限制 | 含义 |
+| --- | --- | --- | --- | --- |
+| `definingClass` | 字符串 | 是 | 以 `L` 开头、以 `;` 结尾的完整 DEX 类描述符 | 定义目标方法的类。 |
+| `name` | 字符串 | 是 | 1 至 80 个允许字符，支持 `<init>` 和 `<clinit>` | 方法名。 |
+| `parameterTypes` | 字符串数组 | 否 | 最多 16 项，每项为合法参数类型描述符 | 要求精确匹配的参数列表。 |
+
+省略 `parameterTypes` 会匹配同一类中同名方法的任意重载。提供该字段后，参数列表必须完全相同。空数组只匹配无参数方法。
+
+| 类型 | DEX 描述符 |
+| --- | --- |
+| boolean | `Z` |
+| byte | `B` |
+| short | `S` |
+| char | `C` |
+| int | `I` |
+| long | `J` |
+| float | `F` |
+| double | `D` |
+| 对象 | `Ljava/lang/String;` 形式的完整描述符 |
+| 数组 | 每一维在元素描述符前增加一个 `[`，例如 `[I`、`[[Ljava/lang/String;` |
+
+## 可选元数据
+
+### `releaseChannel`
+
+| 值 | 是否进入 Preview Bundle | 是否进入 Stable Bundle | 含义 |
+| --- | --- | --- | --- |
+| `stable` | 是 | 是 | 已完成兼容性和检测结果验证的规则，也是默认值。 |
+| `preview-only` | 是 | 否 | 仍在试验或等待稳定验证的规则。 |
+
+生成器会从 Catalog 中删除 `releaseChannel`。它只控制仓库发布渠道，不是运行时图表元数据。
+
+### `availability`
+
+| 值 | 含义 |
+| --- | --- |
+| `always` | 图表始终可用，也是唯一允许值和默认值。 |
+
+未来 Schema 增加在线可用性限制前，应省略该字段。
+
+### `requiresFeatureInitialization`
+
+| 值 | 含义 |
+| --- | --- |
+| `false` | 不等待特征初始化，默认值。 |
+| `true` | 特征初始化完成前隐藏图表。 |
+
+当前在线证据不依赖特征数据，新规则通常应省略该字段或使用 `false`。
+
+### `controls`
+
+| 值 | 含义 |
+| --- | --- |
+| 省略 | 推荐写法，Schema v1 没有在线图表控件。 |
+| `[]` | 合法，但不会增加任何行为。 |
+| 非空数组 | 非法，校验器会拒绝。 |
+
+### `dashboard`
+
+| 值 | 含义 |
+| --- | --- |
+| `none` | 不提供 Dashboard 集成，也是唯一允许值和默认值。 |
+
+### `fingerprint`
+
+Fingerprint 决定已安装应用数据变化后，LibChecker 何时丢弃图表缓存。它不会开放新的证据读取能力。
+
+| 值 | 默认值 | 适用规则 | 含义 |
+| --- | --- | --- | --- |
+| `standard` | 是 | 只依赖 `target_sdk` 等标准元数据 | 使用不包含特征数据的完整应用信息指纹。 |
+| `artifact` | 否 | 检查原生库、DEX 或 Manifest 内容 | 使用包含应用版本和更新时间等制品变化信息的指纹。 |
+| `features` | 否 | 依赖 LibChecker 已初始化特征数据的规则 | 将特征数据纳入缓存指纹，Schema v1 当前在线证据不需要此值。 |
+
+应选择能够覆盖规则中所有证据叶子的值。Target SDK 与 DEX 组合的规则应使用 `artifact`。
+
+## 校验与测试
+
+运行：
+
+```shell
+python3 -m unittest chart.tools.test_build_bundle
+```
+
+JSON Schema 定义完整的对象结构与字段限制。Python 生成器还会进行语义校验，包括证据、操作符和值的兼容性，URL 安全性，图标路径和 SVG 安全性，重复规则 ID，重复 Facet ID，以及复杂度限制。
+
+新增规则时，请更新 `chart/tools/test_build_bundle.py` 中的现有断言：
+
+| 测试位置 | 需要修改的内容 |
+| --- | --- |
+| `test_source_rules_are_valid` | 按排序后的顺序添加新规则 ID。 |
+| `test_bundle_is_deterministic_and_contains_only_expected_files` | 按 ZIP 中的排序添加图标路径，并修改 Catalog 数量。 |
+| `test_stable_bundle_excludes_preview_only_rules` | 根据规则渠道修改稳定 Bundle 的规则 ID 列表。 |
+| 新的专门测试 | 固定关键判定值、条件顺序、图标渲染模式、详情 URL 或其他不能被误改的属性。 |
+| 新 Schema 能力或校验分支 | 添加对应的非法输入测试。 |
+
+不要为了让新规则通过测试而降低限制或删除回归断言。
+
+## 生成 Bundle
+
+本地预览时，先输出到临时目录，避免修改 Git 已跟踪的生成文件：
+
+```shell
+python3 chart/tools/build_bundle.py \
+  --bundle-version 12 \
+  --channel preview \
+  --minimum-app-version-code 2731 \
+  --output-dir /tmp/libchecker-chart-preview
+```
+
+生成目标分支最终制品时，省略 `--output-dir`，文件会写入 `chart/cloud/v1/`：
+
+```shell
+python3 chart/tools/build_bundle.py \
+  --bundle-version 12 \
+  --channel preview \
+  --minimum-app-version-code 2731
+```
+
+### 命令行参数
+
+| 参数 | 是否必填 | 类型与全部可选值 | 默认值 | 含义 |
+| --- | --- | --- | --- | --- |
+| `--bundle-version` | 是 | 大于 `0` 的整数 | 无 | 目标分支单调递增的发布版本。 |
+| `--channel` | 否 | `preview`、`stable` | `preview` | Preview 包含全部规则；Stable 排除 `preview-only`。 |
+| `--minimum-app-version-code` | 否 | 不小于 `0` 的整数 | `0` | 能安全加载 Bundle 中所有规则的首个 LibChecker Version Code。 |
+| `--output-dir` | 否 | 文件系统路径 | `chart/cloud/v1/` | Bundle 与 Manifest 的输出目录。 |
+
+如果规则只使用已发布客户端支持的证据和计算能力，可以沿用目标分支当前兼容的最低应用版本。规则依赖新的客户端能力时，应先协调客户端修改，并填写首个兼容版本的准确 Version Code。不要猜测该值。只有所有仍受支持的客户端都兼容时，才可以发布 `0`。
+
+### 生成结果
+
+| 字段或限制 | 值 | 含义 |
+| --- | --- | --- |
+| 规则排序 | 按 `id` 排序 | 保证 Catalog 稳定。 |
+| 图标排序 | 按路径排序 | 保证 ZIP 条目稳定。 |
+| 最大规则数 | 64 | 超出后生成失败。 |
+| 单个 SVG 最大大小 | 64 KiB | 超出后校验失败。 |
+| Bundle 最大大小 | 2 MiB | 超出后生成失败。 |
+
+`manifest.json` 包含以下参数：
+
+| 参数 | 类型与限制 | 含义 |
+| --- | --- | --- |
+| `schemaVersion` | 固定为 `1` | Catalog 与 Manifest 使用的 Schema 版本。 |
+| `bundleVersion` | 不小于 `1` 的整数 | 当前发布版本。 |
+| `bundleSha256` | 64 位小写十六进制字符串 | `chart.bundle` 的 SHA-256。 |
+| `bundleSize` | 1 至 2,097,152 字节 | `chart.bundle` 的实际字节数。 |
+| `minimumAppVersionCode` | 不小于 `0` 的整数 | 最低兼容 LibChecker Version Code。 |
+
+`chart.bundle` 和 `manifest.json` 必须一起提交。一次生成得到的校验和与大小不能搭配另一次生成得到的 Bundle。
+
+## 人工验证
+
+自动校验只能证明规则格式正确，不能证明规则能够准确识别目标应用。
+
+请求稳定发布前，请完成以下检查：
+
+1. 安装能够读取预览分支的兼容 LibChecker 版本。
+2. 至少检查一个已知匹配应用和一个已知不匹配应用。
+3. 对于 Facet 规则，分别验证每个 Facet，并确认同时匹配多项能力的应用会按照规则顺序显示全部 Chip。
+4. 检查图表标题、分组标题、说明、参考链接、图标大小、图标颜色、浅色主题和深色主题。
+5. 在 PR 描述中记录用于测试的应用版本或样本 APK。
+6. 使用 `--channel stable` 重新生成并检查 Catalog，确保所有 `preview-only` 规则都不在其中。
+
+## Pull Request 检查表
+
+- [ ] 规则只解决一项定义清楚的统计需求。
+- [ ] ID 和文件名稳定并符合命名规范。
+- [ ] 新规则从 Revision `1` 开始，修改已发布规则时已增加 Revision。
+- [ ] 所有文本都有含义一致的 `en` 和 `zh-Hans` 翻译。
+- [ ] 说明保持中性，HTTPS 链接指向一手资料。
+- [ ] 计算只使用受支持的证据和兼容操作符。
+- [ ] DEX Query 使用描述符，并保持同类匹配语义。
+- [ ] SVG 满足安全限制与 `viewBox` 要求。
+- [ ] 发布渠道和 Fingerprint 与规则成熟度、证据类型一致。
+- [ ] 专门测试覆盖关键判定数据和渠道行为。
+- [ ] 单元测试通过。
+- [ ] 已使用兼容的 LibChecker 检查匹配和不匹配应用。
+- [ ] 生成的 Bundle 和 Manifest 已重新生成并一起提交。
+
+## 错误发布后的恢复
+
+不要重新使用旧的 Bundle Version。恢复上一个已知正常的源规则和生成内容，然后用更高的 `bundleVersion` 重新发布。下载、校验和、Schema 或最低版本检查失败时，兼容的 LibChecker 客户端会保留已缓存的 Bundle。


### PR DESCRIPTION
## Summary

- expand the English chart rules README into a complete contribution guide with parameter tables, examples, and submission steps
- add an equivalent Simplified Chinese guide and link both versions from the repository README
- document schema v1 calculations, conditions, evidence types, DEX matching semantics, SVG constraints, validation, bundle generation, and manual verification
- remove references to the deleted Target SDK sample rule

The branch is rebased onto the latest `v4`, and the PR contains one documentation commit only.

## Validation

- `python3 -m unittest chart.tools.test_build_bundle`
- `python3 chart/tools/build_bundle.py --bundle-version 12 --channel preview --minimum-app-version-code 2731 --output-dir <temp-dir>`
- English and Chinese punctuation checks
- `git diff --check upstream/v4...HEAD`
